### PR TITLE
Fix highlight language mapping

### DIFF
--- a/src/utils/highlight.js
+++ b/src/utils/highlight.js
@@ -5,6 +5,7 @@ import 'prismjs/components/prism-cpp';
 import 'prismjs/components/prism-css';
 import 'prismjs/components/prism-dart';
 import 'prismjs/components/prism-docker';
+import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-java';
 import 'prismjs/components/prism-javascript';
 import 'prismjs/components/prism-python';
@@ -15,14 +16,23 @@ import './prism-svelte';
 
 const langMap = {
 	bash: 'bash',
+	c: 'c',
+	'c++': 'cpp',
+	cpp: 'cpp',
 	css: 'css',
 	dart: 'dart',
 	docker: 'docker',
 	html: 'markup',
+	java: 'java',
 	javascript: 'javascript',
 	js: 'javascript',
+	py: 'python',
+	python: 'python',
 	sv: 'svelte',
 	svelte: 'svelte',
+	sql: 'sql',
+	ts: 'typescript',
+	typescript: 'typescript',
 	yaml: 'yaml',
 };
 

--- a/src/utils/highlight.js
+++ b/src/utils/highlight.js
@@ -34,6 +34,7 @@ const langMap = {
 	ts: 'typescript',
 	typescript: 'typescript',
 	yaml: 'yaml',
+	yml: 'yaml',
 };
 
 function highlight(source, langInput) {


### PR DESCRIPTION
- Add `prism-markup` import
- Add languages to `langMap` based on imports
  - c
  - c++
  - java
  - python
  - sql
  - typescript
  - yml
