### PR TITLE
Fix: Code header overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Aqua Changelog
 
+## Unreleased
+
+- Fix code header overflow ([#17](https://github.com/ignatiusmb/aqua/pull/17))
+- Add JSON highlighting ([#12](https://github.com/ignatiusmb/aqua/pull/12))
+- Reduce code header after pseudo-element font-weight ([#12](https://github.com/ignatiusmb/aqua/pull/12))
+
 ## 20.2.3
 
 - Add prepublish routine

--- a/src/code/code.header.css
+++ b/src/code/code.header.css
@@ -37,6 +37,11 @@
 	font-family: var(--aqua-default);
 	font-size: 0.75rem;
 }
+.aqua.code-header > .overflow-wrapper {
+	overflow: hidden;
+	width: 100%;
+	display: inline-flex;
+}
 /* Language Colored Line */
 .aqua.code-header::before {
 	content: '';

--- a/src/code/index.js
+++ b/src/code/index.js
@@ -33,9 +33,9 @@ function encloseBlock(source, dataset) {
 	const { language, title } = dataset;
 	const classes = `class="aqua code-header ${title ? '' : 'empty'}"`;
 	const data = `data-language="${language ? language : ''}"`;
-	const toolbar = createToolbar();
-	const content = title ? `${title} ${toolbar}` : toolbar;
-	const header = `<div ${classes} ${data}>${content}</div>`;
+
+	const content = `<span class="overflow-wrapper">${title || ''}</span>`;
+	const header = `<header ${classes} ${data}>${content}${createToolbar()}</header>`;
 
 	const codeBlock = wrapSource(source, dataset);
 	return `<pre class="aqua code-box">${header}${codeBlock}</pre>`;


### PR DESCRIPTION
Fix code header overflow when content is longer than the available space on smaller viewports